### PR TITLE
Implement redis password support

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,3 +25,39 @@ It follow the workflow that `containerd` provides:
 respectively stdout, stderr and ready notifier.
 - As soon as logs are ready, 5 is closed
 - 3 and 4 are read async and forwarded to specified endpoint
+
+# Debugging
+
+You can also use this tool to simulate containerd behaviors to write your own shim
+module. On the `tools` directory, you have a small tool used to simulate a `shim` process
+started like it would be on containerd with samed `fd` attached etc.
+
+# Testing
+
+You can test out-of-box the `shim-logs redis` endpoint by compiling `tools` and creating
+small local environment:
+```
+mkdir -p /var/cache/modules/contd/config/maxux
+mkdir -p /var/cache/modules/contd/logs/maxux
+chown $USER /var/cache/modules/contd/logs/maxux
+```
+
+And set the `/var/cache/modules/contd/config/maxux/debug-logs.json` file:
+```json
+[
+    {
+        "type": "redis",
+        "data": {
+            "stdout": "redis://:foobared@127.0.0.2/stdout",
+            "stderr": "redis://127.0.0.1/stderr"
+        }
+    }
+]
+```
+
+You can then start `./shim-spawn` on the `tools` directory to forward generated text to redis.
+Example below use one connection password protected for stdout.
+
+# Cleanup Testing
+
+Just delete debug directory: `rm -rf /var/cache/modules/contd`

--- a/log_redis.c
+++ b/log_redis.c
@@ -22,7 +22,7 @@ int redis_write(void *_self, char *line, int len) {
     return 0;
 }
 
-redis_t *redis_new(char *host, int port, char *channel) {
+redis_t *redis_new(char *host, int port, char *channel, char *password) {
     redis_t *backend;
     struct timeval timeout = { 2, 0 };
 
@@ -37,6 +37,18 @@ redis_t *redis_new(char *host, int port, char *channel) {
     if(backend->conn->err) {
         printf("redis: %s\n", backend->conn->errstr);
         return NULL;
+    }
+
+    if(password) {
+        redisReply *reply;
+
+        if(!(reply = redisCommand(backend->conn, "AUTH %s", password)))
+            diep("redis");
+
+        if(reply->type == REDIS_REPLY_ERROR)
+            printf("redis: authentication failed\n");
+
+        freeReplyObject(reply);
     }
 
     backend->channel = strdup(channel);
@@ -56,7 +68,7 @@ static int redis_attach(const char *url, log_t *target) {
     if(purl->port)
         port = atoi(purl->port);
 
-    if(!(redis = redis_new(purl->host, port, purl->path)))
+    if(!(redis = redis_new(purl->host, port, purl->path, purl->password)))
         return 1;
 
     parsed_url_free(purl);

--- a/shim-logs.h
+++ b/shim-logs.h
@@ -82,7 +82,7 @@
     } redis_t;
 
     int redis_write(void *_self, char *line, int len);
-    redis_t *redis_new(char *host, int port, char *channel);
+    redis_t *redis_new(char *host, int port, char *channel, char *password);
     int redis_extract(container_t *c, json_t *root);
 
     //


### PR DESCRIPTION
Implement redis password support on the redis url.
This also add debug information and testing information.

Trying to connect to a redis password protected without password will lead on stdout:
```
redis: could not access redis: NOAUTH Authentication required.
```
Wrong password will also be notified.
If no `PING` can be sent, an error will be displayed.

This closes #2 