### PR TITLE
error: do not exit on user error

### DIFF
--- a/log_file.c
+++ b/log_file.c
@@ -18,8 +18,11 @@ file_t *file_new(char *path) {
     if(!(backend = calloc(sizeof(file_t), 1)))
         diep("calloc");
 
-    if(!(backend->fp = fopen(path, "w")))
-        diep("fopen");
+    if(!(backend->fp = fopen(path, "w"))) {
+        perror("fopen");
+        free(backend);
+        return NULL;
+    }
 
     backend->write = file_write;
 


### PR DESCRIPTION
When userland errors (like redis error, network issue, file access error, ...) happens, display an error message on stderr and does not exit with error.

When shim process exit, the whole container is stopped. An issue here should not break the whole container. A batter handling of redis reconnection could be implemented but at least now an error won't affect container live system.

The only exception is, when a memory allocation fails, process exit.
Memory allocation error usually mean something really bad on the system.

Closes #1 

This PR should be tested a little bit more before merging.