### PR TITLE
core: logs not consumed anymore for some reason

### DIFF
--- a/container.c
+++ b/container.c
@@ -19,8 +19,8 @@ container_t *container_init() {
     container->errfd = 4;  // stderr fd
 
     if(container->id == NULL) {
-        fprintf(stderr, "[-] could not find container id\n");
-        fprintf(stderr, "[-] ensure your environment is well set\n");
+        errlog("[-] could not find container id\n");
+        errlog("[-] ensure your environment is well set\n");
         exit(EXIT_FAILURE);
     }
 
@@ -34,7 +34,7 @@ container_t *container_init() {
 }
 
 void container_ready(container_t *container) {
-    printf("[+] sending ready signal\n");
+    log("[+] sending ready signal\n");
 
     if(write(container->lockfd, "X", 1) != 1)
         perror("write");
@@ -65,7 +65,7 @@ char *container_load_config(char *path) {
 }
 
 static void *json_error(json_t *root, char *message) {
-    fprintf(stderr, "[-] json: %s\n", message);
+    errlog("[-] json: %s\n", message);
     json_decref(root);
     return NULL;
 }
@@ -93,7 +93,7 @@ container_t *container_load_parse(container_t *c, json_t *root) {
 
         } else {
             // only supporting redis for now
-            fprintf(stderr, "[-] config: unsupported <%s> target\n", stype);
+            errlog("[-] config: unsupported <%s> target\n", stype);
         }
     }
 
@@ -109,7 +109,7 @@ container_t *container_load(container_t *c) {
     // setting up config path
     sprintf(path, "%s/%s/%s-logs.json", CONFDIR, c->namespace, c->id);
 
-    printf("[+] loading configuration: %s\n", path);
+    log("[+] loading configuration: %s\n", path);
     if(!(buffer = container_load_config(path)))
         return NULL;
 
@@ -117,7 +117,7 @@ container_t *container_load(container_t *c) {
     // printf(">> %s\n", buffer);
 
     if(!(root = json_loads(buffer, 0, &error))) {
-        fprintf(stderr, "json error: %d: %s\n", error.line, error.text);
+        errlog("json error: %d: %s\n", error.line, error.text);
         return NULL;
     }
 

--- a/log_redis.c
+++ b/log_redis.c
@@ -15,7 +15,7 @@ int redis_write(void *_self, char *line, int len) {
     redisReply *reply;
 
     if(!(reply = redisCommand(self->conn, "PUBLISH %s %s", self->channel, line))) {
-        fprintf(stderr, "[-] redis error: %s\n", self->conn->errstr);
+        errlog("[-] redis error: %s\n", self->conn->errstr);
         return 1;
     }
 
@@ -29,7 +29,7 @@ redis_t *redis_new(char *host, int port, char *channel, char *password) {
     redisReply *reply;
     struct timeval timeout = { 2, 0 };
 
-    printf("[+] redis backend: [%s:%d / %s]\n", host, port, channel);
+    log("[+] redis backend: [%s:%d / %s]\n", host, port, channel);
 
     if(!(backend = calloc(sizeof(redis_t), 1)))
         diep("calloc");
@@ -40,7 +40,7 @@ redis_t *redis_new(char *host, int port, char *channel, char *password) {
     }
 
     if(backend->conn->err) {
-        fprintf(stderr, "[-] redis: %s\n", backend->conn->errstr);
+        errlog("[-] redis: %s\n", backend->conn->errstr);
         redisFree(backend->conn);
         free(backend);
         return NULL;
@@ -51,7 +51,7 @@ redis_t *redis_new(char *host, int port, char *channel, char *password) {
             diep("redis");
 
         if(reply->type == REDIS_REPLY_ERROR)
-            printf("redis: authentication failed\n");
+            log("redis: authentication failed\n");
 
         freeReplyObject(reply);
     }
@@ -60,7 +60,7 @@ redis_t *redis_new(char *host, int port, char *channel, char *password) {
         diep("redis");
 
     if(reply->type == REDIS_REPLY_ERROR)
-        printf("redis: could not access redis: %s\n", reply->str);
+        log("redis: could not access redis: %s\n", reply->str);
 
     freeReplyObject(reply);
 

--- a/shim-logs.c
+++ b/shim-logs.c
@@ -16,7 +16,7 @@
 FILE *syslogfile = NULL;
 
 void diep(char *str) {
-    perror(str);
+    errlog("[-] %s: %s\n", str, strerror(errno));
     exit(EXIT_FAILURE);
 }
 

--- a/shim-logs.c
+++ b/shim-logs.c
@@ -9,6 +9,9 @@
 #include <sys/stat.h>
 #include "shim-logs.h"
 
+// epoll_wait timeout
+#define EVTIMEOUT 200
+
 void diep(char *str) {
     perror(str);
     exit(EXIT_FAILURE);
@@ -93,7 +96,7 @@ int main() {
     // async fetching logs
     //
     while(1) {
-        int n = epoll_wait(evfd, events, MAXEVENTS, -1);
+        int n = epoll_wait(evfd, events, MAXEVENTS, EVTIMEOUT);
 
         if(n < 0) {
             if(errno == EINTR)

--- a/shim-logs.c
+++ b/shim-logs.c
@@ -10,7 +10,7 @@
 #include "shim-logs.h"
 
 // epoll_wait timeout
-#define EVTIMEOUT 200
+#define EVTIMEOUT 1000
 
 // global logfile (copy of stdout/stderr)
 FILE *syslogfile = NULL;

--- a/shim-logs.h
+++ b/shim-logs.h
@@ -12,8 +12,8 @@
 
     extern FILE *syslogfile;
 
-    #define log(fmt...) { fprintf(stdout, fmt); fprintf(syslogfile, fmt); }
-    #define errlog(fmt...) { fprintf(stderr, fmt); fprintf(syslogfile, fmt); }
+    #define log(fmt...) { fprintf(stdout, fmt); fprintf(syslogfile, fmt); fflush(stdout); fflush(syslogfile); }
+    #define errlog(fmt...) { fprintf(stderr, fmt); fprintf(syslogfile, fmt); fflush(syslogfile); }
 
     //
     // stream

--- a/shim-logs.h
+++ b/shim-logs.h
@@ -10,6 +10,11 @@
     // #define CONFDIR     "/tmp/logconf"
     // #define LOGSDIR     "/tmp/logconf"
 
+    extern FILE *syslogfile;
+
+    #define log(fmt...) { fprintf(stdout, fmt); fprintf(syslogfile, fmt); }
+    #define errlog(fmt...) { fprintf(stderr, fmt); fprintf(syslogfile, fmt); }
+
     //
     // stream
     // contains tools to read and bufferize

--- a/stream.c
+++ b/stream.c
@@ -40,8 +40,19 @@ char *stream_line(stream_t *s) {
         s->line = malloc(s->length);
 
     char *found = strchr(s->reader, '\n');
-    if(!found)
-        return NULL;
+    if(!found) {
+        if(stream_remain(s) == 0 && s->reader == s->buffer) {
+            // there is no space left for new data
+            // and the reader is at the begining of the buffer
+            // this mean the buffer is full and there is no
+            // new line found, we force flush
+            found = s->writer - 1;
+
+        } else {
+            // no new line found yet, waiting more data
+            return NULL;
+        }
+    }
 
     size_t length = found - s->reader + 1;
 


### PR DESCRIPTION
It seems that `shim-logs` sometime stop consuming logs.

After investigation, this was caused by a static buffer waiting for new line, before being flushed. If no new line were found before buffer being full, consumption were stuck.